### PR TITLE
Get version number from Git when building

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,8 +87,8 @@ jobs:
         env:
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path ${{ github.workspace }}/vcpkg_installed/x64-windows/bin -w {dest_dir} {wheel}"
-          CIBW_CONFIG_SETTINGS: "cmake.args='-A x64;-DCMAKE_BUILD_TYPE=Release;-DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake'"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path ${{ github.workspace }}/vcpkg/installed/x64-windows-release/bin -w {dest_dir} {wheel}"
+          CIBW_CONFIG_SETTINGS: "cmake.args='-A x64;-DCMAKE_BUILD_TYPE=Release;-DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake'"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,6 +88,8 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_BUILD_VERBOSITY: 3
+          CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path ${{ github.workspace }}/vcpkg_installed/x64-windows/bin -w {dest_dir} {wheel}"
           CIBW_CONFIG_SETTINGS: "cmake.args='-A x64;-DCMAKE_BUILD_TYPE=Release;-DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake'"
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,16 +73,14 @@ jobs:
         with:
           submodules: true
 
-      - name: vcpkg checkout
-        run: git clone --depth 1 https://github.com/Microsoft/vcpkg.git
-
-      - name: Vcpkg bootstrap Windows
-        run: bootstrap-vcpkg.bat
-        working-directory: vcpkg
-
-      - name: Install 3rd Party
-        run: vcpkg install
-        working-directory: vcpkg
+      - name: vcpkg build
+        id: vcpkg
+        uses: johnwason/vcpkg-action@v6
+        with:
+          manifest-dir: ${{ github.workspace }}
+          triplet: x64-windows-release
+          token: ${{ github.token }}
+          github-binarycache: true
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dummy.txt
 *~
 wheelhouse
 NLPPlus/_version.py
+vcpkg_installed/
+vcpkg/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ bin/
 dummy.txt
 *~
 wheelhouse
+NLPPlus/_version.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.15)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX)
 
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/nlp-engine)
+  message(FATAL_ERROR "Could not find nlp-engine in source directory.  Did you run `git submodule update --init`?")
+endif()
+
 add_subdirectory(nlp-engine)
 include_directories(nlp-engine/cs/include)
 include_directories(nlp-engine/include)

--- a/NLPPlus/__init__.py
+++ b/NLPPlus/__init__.py
@@ -10,18 +10,18 @@ Basic usage:
 
 import json
 import logging
-from shutil import copytree
+from shutil import copytree, rmtree
 from tempfile import TemporaryDirectory
 from os import PathLike, getcwd
 from pathlib import Path
 from typing import Optional, Any
 
-from .bindings import NLP_ENGINE
+from .bindings import NLP_ENGINE  # type: ignore
 
 LOGGER = logging.getLogger("NLPPlus")
 
 
-def maybe_readfile(path: Path):
+def maybe_readfile(path: Path) -> Optional[str]:
     """Bogus utility function to maybe read a file."""
     if not path.exists():
         return None
@@ -77,16 +77,15 @@ class Engine:
 
     def analyze(self, text: str, analyzer_name: str) -> Results:
         """Analyze text with the named analyzer."""
+        outdir = self.working_folder / "analyzers" / analyzer_name / "output"
         outtext = self.engine.analyze(analyzer_name, text)
-        return Results(
-            outtext, self.working_folder / "analyzers" / analyzer_name / "output"
-        )
+        return Results(outtext, outdir)
 
 
 engine = Engine()
 
 
-def set_working_folder(working_folder: str = None):
+def set_working_folder(working_folder: Optional[str] = None):
     """Reinitialize the NLP++ engine with a different working folder.
 
     Args:
@@ -97,7 +96,7 @@ def set_working_folder(working_folder: str = None):
     global engine
     if working_folder is None:
         working_folder = getcwd()
-    engine = Engine(working_folder)
+    engine = Engine(Path(working_folder))
 
 
 def analyze(str: str, parser: str = "parse-en-us"):

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This is a Python package for the NLP++ engine. You can find detailed
 documentation about nlp-engine at
 https://github.com/VisualText/nlp-engine.
 
+The NLP++ engine is a 100% editable engine for natural language
+processing - no black boxes!  This module allows you to integrate
+NLP++ with your Python code.
+
 ## Requirements 
 
 * Python 3.8
@@ -113,16 +117,24 @@ Now you can install with this somewhat more complicated command:
 
 ### Windows Setup
 
-On Windows, the vcpkg setup is just slightly different:
+On Windows, everything is vastly more complicated for a number of
+reasons:
 
-    cd vcpkg
-    bootstrap-vcpkg.bat
+- The ICU library on which NLP++ depends is built as DLLs, and these
+  have to be included with the package
+- Python won't load arbitrary DLLs from the current directory, unlike
+  the rest of Windows (this is a good thing)
+- Builds take 10x longer on Windows than on reasonable operating
+  systems, so you will wait a long time to find out that the module
+  you built actually doesn't work
 
-But the compilation should be the same:
+For this reason "editable" installs (the `-e` option to `pip install`)
+do not work on Windows and can't be expected to work.  Instead it is
+necessary to build a wheel file and "repair" it with
+[delvewheel](https://pypi.org/project/delvewheel/) to package the DLLs
+correctly, then install that wheel.
 
-    pip install --no-build-isolation \
-        -C cmake.args=-DCMAKE_TOOLCHAIN_FILE=./nlp-engine/vcpkg/scripts/buildsystems/vcpkg.cmake \
-        -ve .
+If that sounds like too much trouble then just install from PyPI.
 
 ### Testing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "NLPPlus"
-version = "1.1.0"
+dynamic = ["version"]
 authors = [
     {name = "David De Hilster", email="contact@visualtext.org"}
 ]
@@ -33,6 +33,11 @@ Issues = "https://github.com/VisualText/py-package-nlpengine"
 
 [tool.scikit-build]
 build-dir = "build/{wheel_tag}"
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+sdist.include = ["NLPPlus/_version.py"]
+
+[tool.setuptools_scm]
+write_to = "NLPPlus/_version.py"
 
 [tool.cibuildwheel]
 build = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 nanobind
 scikit-build-core[pyproject]
-
+cmake
+setuptools_scm

--- a/tests/data/emailaddress/text.txt_log/output.json
+++ b/tests/data/emailaddress/text.txt_log/output.json
@@ -33,7 +33,8 @@
 		{
 		"emailadd-id":"5",
 		"local":"alice.smith",
-		"domainname":"dept.departmentname.university"
+		"domainname":"dept.departmentname.university",
+		"country":"UnitedKingdom"
 	},
 		{
 		"emailadd-id":"6",
@@ -50,12 +51,18 @@
 		{
 		"emailadd-id":"8",
 		"local":"user_name",
-		"domainname":"subdomain.co.uk"
+		"domainname":"subdomain",
+		"tld":"co",
+		"cd":"uk",
+		"country":"UnitedKingdom"
 	},
 		{
 		"emailadd-id":"9",
 		"local":"kenethfpp",
-		"domainname":"mails.yahoo.uk"
+		"domainname":"mails",
+		"tld":"yahoo",
+		"cd":"uk",
+		"country":"UnitedKingdom"
 	},
 		{
 		"emailadd-id":"10",
@@ -78,7 +85,10 @@
 		{
 		"emailadd-id":"13",
 		"local":"jane_doe",
-		"domainname":"outlook.co.uk"
+		"domainname":"outlook",
+		"tld":"co",
+		"cd":"uk",
+		"country":"UnitedKingdom"
 	},
 		{
 		"emailadd-id":"14",
@@ -129,24 +139,48 @@
 	},
 		{
 		"emailadd-id":"22",
+		"local":"webmaster",
+		"domainname":"emailserver",
+		"tld":"biz"
+	},
+		{
+		"emailadd-id":"23",
 		"local":"no_reply",
 		"domainname":"noreply-domain",
 		"tld":"info"
 	},
 		{
-		"emailadd-id":"23",
+		"emailadd-id":"24",
 		"local":"admin",
 		"domainname":"server123",
 		"tld":"net"
 	},
 		{
-		"emailadd-id":"24",
+		"emailadd-id":"25",
+		"local":"test.email",
+		"domainname":"emailprovider",
+		"tld":"co"
+	},
+		{
+		"emailadd-id":"26",
 		"local":"marketing.department",
 		"domainname":"email",
 		"tld":"org"
 	},
 		{
-		"emailadd-id":"25",
+		"emailadd-id":"27",
+		"local":"me",
+		"domainname":"myname",
+		"tld":"me"
+	},
+		{
+		"emailadd-id":"28",
+		"local":"contact-sales",
+		"domainname":"email-service",
+		"tld":"io"
+	},
+		{
+		"emailadd-id":"29",
 		"local":"support",
 		"domainname":"customer-service",
 		"tld":"pro"

--- a/tests/data/emailaddress/text.txt_log/output.json
+++ b/tests/data/emailaddress/text.txt_log/output.json
@@ -33,8 +33,7 @@
 		{
 		"emailadd-id":"5",
 		"local":"alice.smith",
-		"domainname":"dept.departmentname.university",
-		"country":"UnitedKingdom"
+		"domainname":"dept.departmentname.university"
 	},
 		{
 		"emailadd-id":"6",
@@ -51,18 +50,12 @@
 		{
 		"emailadd-id":"8",
 		"local":"user_name",
-		"domainname":"subdomain",
-		"tld":"co",
-		"cd":"uk",
-		"country":"UnitedKingdom"
+		"domainname":"subdomain.co.uk"
 	},
 		{
 		"emailadd-id":"9",
 		"local":"kenethfpp",
-		"domainname":"mails",
-		"tld":"yahoo",
-		"cd":"uk",
-		"country":"UnitedKingdom"
+		"domainname":"mails.yahoo.uk"
 	},
 		{
 		"emailadd-id":"10",
@@ -85,10 +78,7 @@
 		{
 		"emailadd-id":"13",
 		"local":"jane_doe",
-		"domainname":"outlook",
-		"tld":"co",
-		"cd":"uk",
-		"country":"UnitedKingdom"
+		"domainname":"outlook.co.uk"
 	},
 		{
 		"emailadd-id":"14",
@@ -139,48 +129,24 @@
 	},
 		{
 		"emailadd-id":"22",
-		"local":"webmaster",
-		"domainname":"emailserver",
-		"tld":"biz"
-	},
-		{
-		"emailadd-id":"23",
 		"local":"no_reply",
 		"domainname":"noreply-domain",
 		"tld":"info"
 	},
 		{
-		"emailadd-id":"24",
+		"emailadd-id":"23",
 		"local":"admin",
 		"domainname":"server123",
 		"tld":"net"
 	},
 		{
-		"emailadd-id":"25",
-		"local":"test.email",
-		"domainname":"emailprovider",
-		"tld":"co"
-	},
-		{
-		"emailadd-id":"26",
+		"emailadd-id":"24",
 		"local":"marketing.department",
 		"domainname":"email",
 		"tld":"org"
 	},
 		{
-		"emailadd-id":"27",
-		"local":"me",
-		"domainname":"myname",
-		"tld":"me"
-	},
-		{
-		"emailadd-id":"28",
-		"local":"contact-sales",
-		"domainname":"email-service",
-		"tld":"io"
-	},
-		{
-		"emailadd-id":"29",
+		"emailadd-id":"25",
 		"local":"support",
 		"domainname":"customer-service",
 		"tld":"pro"


### PR DESCRIPTION
Use the release tags to set the version number in the Python packages - with luck everything should Just Work when a release is made on GitHub!

This also repairs the Windows wheels to include the ICU DLLs, and also adds vcpkg caching on Windows (no need to do this on reasonable operating systems where building from source doesn't take an eternity)