### PR TITLE
Suppress PermissionError on tempdir cleanup on Windows (NLP-ENGINE-523)

### DIFF
--- a/NLPPlus/__init__.py
+++ b/NLPPlus/__init__.py
@@ -84,7 +84,18 @@ class Engine:
         initialize: bool = False,
     ):
         if working_folder is None:
-            self.tmpdir = TemporaryDirectory(prefix="NLPPlus-")
+            # ignore_cleanup_errors=True: the nlp-engine's static `cgerr`
+            # ofstream holds <analyzer>/logs/cgerr.log open for the
+            # lifetime of the process. Python's TemporaryDirectory
+            # cleanup runs during atexit, but the C++ static destructor
+            # that would close cgerr runs *after* atexit (Python returns
+            # control to the OS first). On Windows that ordering means
+            # cleanup hits a still-open file and raises PermissionError.
+            # Swallow it — the OS reclaims the tempdir at process exit
+            # regardless. Tracked engine-side as NLP-ENGINE-523.
+            self.tmpdir = TemporaryDirectory(
+                prefix="NLPPlus-", ignore_cleanup_errors=True
+            )
             self.working_folder = Path(self.tmpdir.name)
             initialize = True
         else:


### PR DESCRIPTION
## Summary
The default `Engine()` uses a `TemporaryDirectory` as its working folder. On Windows the engine's static `cgerr` ofstream holds `<analyzer>/logs/cgerr.log` open for the lifetime of the process. Python's `TemporaryDirectory` cleanup runs during `atexit`; the C++ static destructor that would close `cgerr` runs *after* `atexit` (Python hands control back to the OS first). That ordering means `TemporaryDirectory` cleanup hits a still-open file and raises `PermissionError` on Windows, dumping a noisy traceback at the end of any script using the default working folder.`n`nThe OS reclaims the tempdir at process exit regardless of whether Python's cleanup succeeded, so suppressing the error is safe. Setting `ignore_cleanup_errors=True` (Python 3.10+) does exactly that.`n`nProperly fixing the engine-side root cause (NLP-ENGINE-523 - make `cgerr` lazy/per-engine, or release the handle in `NLP_ENGINE::close()` instead of relying on static destruction order) is a bigger refactor; tracked but not in this PR.`n`n## Test plan`n- [ ] Run any script using `NLPPlus.analyze` / `NLPPlus.cloud_compile` on Windows. Should exit without the `PermissionError` traceback that previously appeared during interpreter shutdown.`n- [ ] Linux / macOS behaviour unchanged (those don't hold file handles open under the same ordering).