### PR TITLE
test: verify #632 segfault fixed by nlp-engine #658 (engine 3.5.6)

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -96,6 +96,41 @@ class EngineTest(TestCase):
         self._run_analyzer("links")
 
 
+class ReentrancyRegressionTest(TestCase):
+    """nlp-engine #658 / #632 regression.
+
+    Re-entrant ``analyze()`` across working folders must reuse the loaded
+    analyzer instead of rebuilding and orphaning it, and switching working
+    folders (which tears down the prior engine) must not segfault on teardown.
+
+    Unlike the fixture-based suites above, these tests assert only that the
+    calls succeed and -- critically -- that the process survives teardown.
+    They deliberately do NOT compare against the output fixtures (which drift
+    with the engine and are regenerated separately), so a clean run here is an
+    unambiguous signal that the #632 SIGSEGV (exit 139) is gone.
+    """
+
+    def test_repeated_analyze_same_process(self):
+        """Several analyze() calls in one process exercise the re-entrant
+        addAna path that, pre-#658, logged 'Named analyzer already present'
+        and orphaned a fresh NLP. Uses the bundled default analyzer."""
+        for _ in range(3):
+            xml = NLPPlus.analyze("Hello world!")
+            self.assertTrue(xml)
+
+    def test_working_dir_switch_teardown(self):
+        """The #632 repro: switch to a temp working folder, analyze, then let
+        TemporaryDirectory GC-clean it -- which tears down the prior engine.
+        Pre-#658 this SIGSEGV'd during teardown; post-fix it exits cleanly."""
+        with TemporaryDirectory(prefix="test-nlpplus") as tmp:
+            copytree(DATADIR.parent / "analyzers", Path(tmp) / "analyzers")
+            copytree(NLPPLUSDIR / "data", Path(tmp) / "data")
+            NLPPlus.set_working_folder(tmp)
+            text = read_file(DATADIR / "basic" / "text.txt")
+            results = NLPPlus.engine.analyze(text, "basic")
+            self.assertIsNotNone(results)
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     main()


### PR DESCRIPTION
Verifies that **nlp-engine #658** (re-entrant `analyze()` orphaning/segfault on a path-form mismatch) resolves the SIGSEGV reported in **VisualText/nlp-engine#632**.

## Changes
- Bump the `nlp-engine` submodule `3355d34 → 2b156ba` (engine **3.5.6**, carrying the #658 fix).
- Add `ReentrancyRegressionTest` (non-skipped) reproducing the #632 crash path:
  - repeated `analyze()` in one process (the re-entrant `addAna` path that used to log "Named analyzer already present" and orphan a fresh NLP), and
  - switch to a temp working folder, analyze, then let `TemporaryDirectory` tear down the prior engine — the exact teardown that produced `exit code 139`.

  These assert the calls succeed and the **process survives**; they intentionally do **not** compare against the drifted output fixtures, so a green run is an unambiguous "no SIGSEGV" signal.

## Why not just un-skip the existing suites
The existing `ModuleTest`/`EngineTest` are skipped for **two** reasons (per the in-file comment): the destructor segfault (#632, fixed here) **and** output-format drift in the `text.txt_log` fixtures. The fixtures still need regeneration, so those stay skipped; this PR isolates the crash fix so CI gives a clean signal.

## Expected
`test.yml` (ubuntu) runs the suite to completion — the unittest summary prints and the job exits 0, where pre-#658 the process died with exit 139 before the summary.

Closes VisualText/nlp-engine#632 once green (and the engine 3.5.6 release ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)