### PR TITLE
fix: bundle rfb/spec/xvar.nlp by re-syncing vendored NLPPlus/data with engine

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,13 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+    - name: Verify vendored data is in sync with engine
+      # NLPPlus/data is a committed copy of the engine's data/ tree that the
+      # wheel ships and __init__.py copies into the working folder at runtime.
+      # If it drifts, compiler passes added to the engine (e.g. rfb/spec/xvar.nlp
+      # for _xVAR) are missing and analyzers fail to build. Fail fast on drift;
+      # re-sync with: rsync -a --delete nlp-engine/data/ NLPPlus/data/
+      run: diff -rq nlp-engine/data NLPPlus/data
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'

--- a/.github/workflows/update-nlp-engine.yml
+++ b/.github/workflows/update-nlp-engine.yml
@@ -58,6 +58,14 @@ jobs:
           before=$(git rev-parse HEAD:nlp-engine)
           git submodule update --remote --recursive nlp-engine
           after=$(git -C nlp-engine rev-parse HEAD)
+          # Keep the vendored rule-compiler spec (NLPPlus/data) in lockstep with
+          # the engine's data/ tree. The wheel ships this copy and __init__.py
+          # copies it into the working folder at runtime; if it drifts, newly
+          # added compiler passes (e.g. rfb/spec/xvar.nlp, which teaches the
+          # compiler _xVAR("attr")) are missing and analyzers fail to build even
+          # though the engine source is correct. Mirror with --delete so removed
+          # files are dropped too.
+          rsync -a --delete nlp-engine/data/ NLPPlus/data/
           echo "latest=$latest"       >> "$GITHUB_OUTPUT"
           echo "published=$published" >> "$GITHUB_OUTPUT"
           echo "before=$before"       >> "$GITHUB_OUTPUT"
@@ -87,7 +95,7 @@ jobs:
         if: steps.bump.outputs.changed == 'true'
         run: |
           set -euo pipefail
-          git add nlp-engine
+          git add nlp-engine NLPPlus/data
           # The submodule may already be at `after` on main (advanced by another
           # path), leaving nothing to commit -- but we still need the tag to fire
           # publish.yml. Commit only when there's an actual change.

--- a/NLPPlus/data/rfb/spec/analyzer.seq
+++ b/NLPPlus/data/rfb/spec/analyzer.seq
@@ -3,7 +3,8 @@ tokenize		#
 line		# 
 pat	retok	# 
 pat	bigtok	# 
-pat	x_white	# 
+pat	x_white	#
+pat	xvar	# merge _xVAR("attr") into one nonliteral token
 pat	nlppp	# comment here
 pat	un_mark	# comment here
 pat	list	# 

--- a/NLPPlus/data/rfb/spec/bigtok.nlp
+++ b/NLPPlus/data/rfb/spec/bigtok.nlp
@@ -96,7 +96,7 @@ _soRULES [base layer=(_startMark)] <- \@ RULES [t] @@
 	rfanonlit(2)
 	single()
 @RULES
-_NONLIT [base] <- \_ _xWILD [s one match=(_xALPHA _xEMOJI)] @@
+_NONLIT [base] <- \_ _xWILD [s plus match=(_xALPHA _xEMOJI _xNUM)] @@	# 06/11/26 DD. plus + _xNUM: allow digits in names (_B2, _34, _C25g).
 
 @RULES
 _ARROW [base] <- \< \- @@

--- a/NLPPlus/data/rfb/spec/xvar.nlp
+++ b/NLPPlus/data/rfb/spec/xvar.nlp
@@ -1,0 +1,16 @@
+###############################################
+# FILE:     XVAR.PAT
+# SUBJ:     Merge _xVAR("attr") into a single nonliteral match-list token.
+# NOTE:     Runs after bigtok forms _NONLIT/_STR and whitespace is zapped,
+#           and before list collects parenthesized match lists, so the inner
+#           parens of _xVAR("attr") never reach the list grammar.  The merged
+#           token _xVAR("attr") then flows through as one restricted-wildcard
+#           match-list entry; Pat::modeMatch1 tests the node attribute at
+#           runtime.
+###############################################
+
+@POST
+	rfaxvar(1,3)
+	single()
+@RULES
+_NONLIT [base] <- _NONLIT \( _STR \) @@

--- a/NLPPlus/data/rfb/spec/xvar.nlp
+++ b/NLPPlus/data/rfb/spec/xvar.nlp
@@ -1,16 +1,21 @@
 ###############################################
 # FILE:     XVAR.PAT
-# SUBJ:     Merge _xVAR("attr") into a single nonliteral match-list token.
+# SUBJ:     Merge _xVAR("attr") / _xVAR(attr) into a single nonliteral token.
 # NOTE:     Runs after bigtok forms _NONLIT/_STR and whitespace is zapped,
 #           and before list collects parenthesized match lists, so the inner
-#           parens of _xVAR("attr") never reach the list grammar.  The merged
+#           parens of _xVAR(attr) never reach the list grammar.  The merged
 #           token _xVAR("attr") then flows through as one restricted-wildcard
 #           match-list entry; Pat::modeMatch1 tests the node attribute at
-#           runtime.
+#           runtime.  The attribute may be quoted (_STR) or an unquoted bareword
+#           (_LIT/_NUM); Pat::xvarMatch strips the optional quotes either way.
 ###############################################
 
 @POST
 	rfaxvar(1,3)
 	single()
 @RULES
+# Quoted attr:    _xVAR("attr")
 _NONLIT [base] <- _NONLIT \( _STR \) @@
+# Unquoted attr:  _xVAR(attr)  /  _xVAR(123)
+_NONLIT [base] <- _NONLIT \( _LIT \) @@
+_NONLIT [base] <- _NONLIT \( _NUM \) @@


### PR DESCRIPTION
## Problem

The NLPPlus 2.0.20 wheel fails to build any analyzer that uses `_xVAR(...)` (`Couldn't build analyzer.`), even though the engine source on `master` has the fix (PRs #647 and #677) and the 2.0.20 submodule includes them.

Root cause is **packaging, not engine source**: `NLPPlus/data/` is a hand-vendored copy of the engine's `data/` tree, committed in this repo. The wheel ships it and `__init__.py` copies it into the working folder at runtime. There is **no build-time sync** from the `nlp-engine` submodule, so when the engine added the `_xVAR("attr")` rule-compiler pass, the vendored copy never picked it up.

Drift was exactly 3 files under `data/rfb/spec/`:
- `xvar.nlp` — **missing entirely** (the pass that teaches the compiler `_xVAR("attr")`)
- `analyzer.seq` — missing the `pat xvar` line that runs the pass
- `bigtok.nlp` — missing the `_xNUM`-in-names fix

With no `xvar` pass, the rule compiler has no handler for `_xVAR(...)`, so any analyzer using it fails to build and returns null.

## Fix

1. **Re-sync** `NLPPlus/data` with `nlp-engine/data` (adds `xvar.nlp`, updates `analyzer.seq` + `bigtok.nlp`). `diff -rq nlp-engine/data NLPPlus/data` is now clean.
2. **Prevent future drift:**
   - `update-nlp-engine.yml`: `rsync -a --delete nlp-engine/data/ NLPPlus/data/` on every engine bump, staged with the submodule.
   - `test.yml`: a `diff -rq` guard that fails any PR where the two trees drift.

## Release note

This is a data-only fix; the engine SHA is unchanged from 2.0.20, so the automated bump workflow won't ship it. After merge, push a `v2.0.21` tag to trigger `publish.yml`.

## Acceptance

- Wheel contains `NLPPlus/data/rfb/spec/xvar.nlp`.
- In a fresh process, an `_xVAR(...)` analyzer builds and returns output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)