### PR TITLE
ci: build cp313 wheels (bump cibuildwheel v2.19.2 -> v2.23.4)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,10 @@ jobs:
           submodules: recursive
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.2
+        # cibuildwheel must be new enough to know the cp313 identifier;
+        # v2.19.2 predates CPython 3.13 and silently skips the cp313-* entry
+        # in pyproject's build list, leaving 3.13 users with no wheel.
+        uses: pypa/cibuildwheel@v2.23.4
         env:
           CIBW_BUILD_VERBOSITY: 3
           # Note use of yum because anylinux is ancient CentOS
@@ -84,7 +87,9 @@ jobs:
           github-binarycache: true
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.2
+        # See the Linux job: v2.19.2 is too old to build cp313, so 3.13
+        # Windows users fall through to the unbuildable sdist.
+        uses: pypa/cibuildwheel@v2.23.4
         env:
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"


### PR DESCRIPTION
## Problem

`pip install NLPPlus` fails on **Python 3.13** (it falls through to the source sdist, which can't build without an ICU toolchain). Root cause: the publish matrix has been shipping **cp310/cp311/cp312** wheels but **no cp313**, even though `pyproject.toml`'s `[tool.cibuildwheel].build` lists `cp313-*`.

`publish.yml` pinned `pypa/cibuildwheel@v2.19.2` (June 2024), which predates CPython 3.13 and **silently skips** the unknown `cp313` build identifier. Every release from 2.0.14 through 2.0.21 is affected.

### Evidence

- v2.0.21 `upload_pypi` logged `200 OK` for cp310/311/312 wheels + sdist — uploads succeed; cp313 was simply never built.
- PyPI serves the 2.0.21 `cp312-win_amd64` wheel but returns "no matching distribution" for cp313.
- `cibuildwheel --print-build-identifiers` against this repo's config:
  - `v2.19.2` → `cp310 / cp311 / cp312`
  - `v2.23.4` → `cp310 / cp311 / cp312 / cp313`

## Fix

Bump both the Linux and Windows jobs `pypa/cibuildwheel@v2.19.2 → v2.23.4` (latest 2.x; cp313 has been a default build target since 2.21.3). This keeps the existing `CIBW_*` configuration untouched and is the lowest-risk change that restores cp313 coverage — v3/v4 carry breaking changes not validated here.

The `skip` list (musllinux, i686, win32, macos-arm64) is still honored.

## Follow-up (not in this PR)

The **macOS** job uses bare `pip wheel .` against the runner's host Python, so it currently ships only a single `cp314` wheel and nothing for cp310–cp313. macOS users are under-covered too; fixing it means converting that job to cibuildwheel + vcpkg — worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
