### PR TITLE
ci: build full cp310-cp313 macOS wheels via cibuildwheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,22 +49,33 @@ jobs:
         with:
           submodules: recursive
 
+      # Autotools are needed for vcpkg to build ICU from source on a cache miss.
       - name: Install packages
         run: brew install autoconf-archive autoconf automake pkg-config
 
-      - name: vcpkg setup
-        run: |
-          git clone --depth 1 https://github.com/Microsoft/vcpkg.git
-          ./vcpkg/bootstrap-vcpkg.sh
+      - name: vcpkg build
+        id: vcpkg
+        uses: johnwason/vcpkg-action@v6
+        with:
+          manifest-dir: ${{ github.workspace }}
+          triplet: arm64-osx-release
+          token: ${{ github.token }}
+          github-binarycache: true
 
+      # Replaces the previous bare `pip wheel`, which only built a single wheel
+      # for the runner's host Python (leaving cp310-cp312 macOS users with no
+      # wheel) and did not bundle the ICU dylibs. cibuildwheel builds the full
+      # cp310-cp313 matrix and its default delocate step vendors the dylibs.
       - name: Build wheels
-        run: |
-          pip wheel -C "cmake.args=-DCMAKE_BUILD_TYPE=Release;-DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake" -v .
+        uses: pypa/cibuildwheel@v2.23.4
+        env:
+          CIBW_BUILD_VERBOSITY: 3
+          CIBW_CONFIG_SETTINGS: "cmake.args='-DCMAKE_BUILD_TYPE=Release;-DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake'"
 
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-macos
-          path: ./*.whl
+          path: ./wheelhouse/*.whl
 
   build_wheels_windows:
     name: Build wheels on Windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,9 @@ build = [
       "cp313-*",
 ]
 skip = [
-     "cp*-macosx_arm64",
+     # macosx_arm64 is intentionally built: the macOS job runs cibuildwheel
+     # natively on an arm64 (Apple Silicon) runner, so skipping arm64 here
+     # would leave that job with nothing to build.
      "*_i686",
      "*musl*",
      "*-win32",


### PR DESCRIPTION
## Problem

Follow-up to #34 (which fixed the missing **cp313** wheels on Linux/Windows). The **macOS** job was still under-building:

```yaml
- name: Build wheels
  run: pip wheel -C "cmake.args=..." -v .
```

A bare `pip wheel .` builds exactly **one** wheel — for the runner's host Python (currently cp314) — and bundles **no ICU dylibs**. So macOS users on cp310–cp313 got no wheel and fell through to the source sdist, which can't build without a local ICU/vcpkg toolchain. Recent releases show this: only a lone `cp314-macosx_arm64` wheel, nothing for cp310–cp313.

## Fix

- **`publish.yml`**: convert the macOS job to `pypa/cibuildwheel@v2.23.4` (same as the Linux/Windows jobs). ICU comes from the vcpkg manifest via `johnwason/vcpkg-action` (mirroring the Windows job), and cibuildwheel's default **delocate** repair vendors the dylibs into each wheel — something the bare `pip wheel` never did.
- **`pyproject.toml`**: drop `cp*-macosx_arm64` from `skip`. `macOS-latest` is an arm64 (Apple Silicon) runner, so with the skip in place cibuildwheel would build **nothing**. (It was only harmless before because the bare `pip wheel` bypassed cibuildwheel entirely.)

### Result

`cibuildwheel --print-build-identifiers --platform macos --arch arm64` against this config:

```
cp310-macosx_arm64
cp311-macosx_arm64
cp312-macosx_arm64
cp313-macosx_arm64
```

Full cp310–cp313 coverage, consistent with Linux/Windows. Note this intentionally drops the lone cp314 wheel — cibuildwheel 2.23.4's build set is cp310–cp313, matching the other platforms. The wheels also pick up cibuildwheel's default arm64 deployment target (macosx_11_0), so they install on more Macs than the previous macosx_15+/26 tags.

## Validation

`publish.yml` runs `on: pull_request` (the upload/release steps are gated on `refs/tags/v*`), so **this PR's CI builds the macOS wheels without publishing**. Please check the "Build wheels on MacOS" job on this PR produces cp310–cp313 `macosx_arm64` wheels before merging. After merge, a normal release (the Release workflow) will publish them.

## Not in scope

Intel macOS (`macosx_x86_64`) wheels — would need an Intel runner (`macos-13`) or cross-build; the project has only ever shipped arm64. Can be a separate PR if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
