### PR TITLE
Load pre-compiled NLP++ analyzers (engine 3.7.11 + ICU preload)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,7 +104,16 @@ jobs:
         env:
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path ${{ github.workspace }}/vcpkg/installed/x64-windows-release/bin -w {dest_dir} {wheel}"
+          # --no-mangle-all + --add-dll icuin<ver>.dll are required so a *compiled*
+          # NLP++ analyzer (bin/run.dll / bin/kb.dll, dlopened at analyze time)
+          # can resolve its ICU imports. It imports icuin<ver>.dll + icuuc<ver>.dll
+          # by their real names; the default delvewheel run mangles those names and
+          # only vendors icuuc/icudt (what our extension itself imports), so the
+          # analyzer's icuin import goes unresolved and kb.dll fails to load. Keep
+          # real names (--no-mangle-all) and force-vendor icuin (--add-dll); the
+          # package then preloads them by name at import (NLPPlus._preload_icu).
+          # NOTE: bump "78" if the vcpkg ICU major version changes.
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --no-mangle-all --add-dll icuin78.dll --add-path ${{ github.workspace }}/vcpkg/installed/x64-windows-release/bin -w {dest_dir} {wheel}"
           CIBW_CONFIG_SETTINGS: "cmake.args='-A x64;-DCMAKE_BUILD_TYPE=Release;-DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake'"
 
       - uses: actions/upload-artifact@v4

--- a/NLPPlus/__init__.py
+++ b/NLPPlus/__init__.py
@@ -18,9 +18,63 @@ from typing import Optional, Any
 import os
 import glob
 
-from .bindings import NLP_ENGINE  # type: ignore
-
 LOGGER = logging.getLogger("NLPPlus")
+
+
+def _preload_icu() -> None:
+    """Load the vendored ICU (and MSVC runtime) DLLs by their real names.
+
+    A *compiled* NLP++ analyzer ships as a self-contained shared library
+    (``bin/run.<ext>`` / ``bin/kb.<ext>``) that imports ``icuin<ver>.dll``
+    and ``icuuc<ver>.dll`` **by name**.  The engine loads that library at
+    analyze time with a plain ``LoadLibrary(full_path)``, whose dependency
+    resolution only consults modules already loaded in the process (matched
+    by base name), the library's own directory, and the system path — it
+    does *not* consult ``os.add_dll_directory`` entries.
+
+    Our own extension only pulls in ``icuuc`` (+ its ``icudt`` data), so
+    without help ``icuin`` is never loaded and the compiled KB library fails
+    with ``[Couldn't load library: ...\\bin\\kb.dll]``.  Pre-loading every
+    vendored ``icu*``/``msvcp*`` DLL here, in dependency order and under
+    their real (un-mangled) names, makes them memory-resident so a compiled
+    analyzer binds them straight from memory.  Requires the wheel to have
+    been repaired with ``--no-mangle-all`` (real names) and ``icuin`` force
+    added via ``--add-dll`` since it is not a dependency of our extension.
+
+    No-op off Windows (Linux/macOS resolve ``.so``/``.dylib`` deps via
+    ``RPATH``/``@loader_path`` set by ``auditwheel``/``delocate``).
+    """
+    if os.name != "nt":
+        return
+    import ctypes
+
+    here = Path(__file__).resolve().parent
+    # delvewheel vendors DLLs into a sibling ``<distribution>.libs`` folder.
+    libdirs = [
+        here.parent / "nlpplus.libs",
+        here.parent / "NLPPlus.libs",
+    ]
+    for libs in libdirs:
+        if not libs.is_dir():
+            continue
+        try:
+            os.add_dll_directory(str(libs))
+        except (OSError, AttributeError):
+            pass
+        # Dependency order: data (icudt) -> common (icuuc) -> i18n (icuin).
+        # msvcp is pulled first as the C++ runtime the analyzer also imports.
+        for stem in ("msvcp", "vcruntime", "icudt", "icuuc", "icuin"):
+            for dll in sorted(libs.glob(stem + "*.dll")):
+                try:
+                    ctypes.WinDLL(str(dll))
+                except OSError:
+                    pass
+        break
+
+
+_preload_icu()
+
+from .bindings import NLP_ENGINE  # type: ignore  # noqa: E402
 
 
 def maybe_readfile(path: Path) -> Optional[str]:


### PR DESCRIPTION
## What
Makes `analyze(..., compiled=True)` load and run a **pre-compiled** NLP++ analyzer (single combined DLL deploy) from a fresh engine and produce correct output.

## Changes
- **nlp-engine submodule** → v3.7.11 (`82ff50e`): combined analyzer+KB DLL; lazy-opens `*-full.dict`/`*-full.kbb` at runtime in compiled mode.
- **`NLPPlus/__init__.py`**: `_preload_icu()` ctypes-loads every vendored `icu*`/`msvcp*` DLL by real name at import (dep order icudt → icuuc → icuin).
- **`.github/workflows/publish.yml`**: repair wheels with `delvewheel --no-mangle-all --add-dll icuin78.dll`.

## Root cause of `[Couldn't load library: bin/kb.dll]`
A compiled analyzer DLL imports `icuin<ver>.dll` + `icuuc<ver>.dll` by real name and is `dlopen`ed via a plain `LoadLibrary(fullpath)`, whose dependency resolution only consults already-loaded modules (by base name), the DLL's own dir, or PATH — **not** `os.add_dll_directory`. Default delvewheel repair mangled the ICU names and never vendored `icuin` (the extension only imports `icuuc`/`icudt`), so the analyzer's ICU imports went unresolved. Keeping real names + force-vendoring `icuin` + preloading them by name fixes it.

## Verification (Windows, cp313)
Fresh temp-dir engine, copy only `compiled/TextGen`, `analyze(..., compiled=True)`: `[Loaded compiled KB library]`, `[Loaded compiled analyzer]`, all four `en-*-full` lazy files open, `output.txt` → `Fee $715.00.`, `verify.json` produced. Interpreted path unchanged.

## Note
Per-render `data.kbb` override (`B=$999`) is out of scope: in compiled mode the engine reads only lazy `*-full` files, and the sample `compiled/TextGen` bakes its dev `data` into the DLL — that belongs to the analyzer/deploy side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)